### PR TITLE
Create the odh-model-controller Repository Write team and add new users

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -270,6 +270,40 @@ orgs:
         privacy: closed
         repos:
           rest-proxy: write
+      repo-odh-model-controller-write:
+        description: "Members with Write access to the odh-model-controller repository"
+        members:
+        - 4n4nd
+        - DaoDaoNoCode
+        - Dbryant58
+        - DharmitD
+        - HumairAK
+        - Jooho
+        - VaishnaviHire
+        - VannTen
+        - Xaenalt
+        - andrewballantyne
+        - atheo89
+        - dchourasia
+        - dfeddema
+        - durandom
+        - gmfrasca
+        - goern
+        - guimou
+        - harshad16
+        - heyselbi
+        - jedemo
+        - jeff-phillips-18
+        - jgarciao
+        - judyobrienie
+        - kywalker-rh
+        - lucferbux
+        - lugi0
+        - maroroman
+        - rimolive
+        privacy: closed
+        repos:
+          odh-model-controller: write
       Notebook Controller Maintainers:
         description: Maintainers of the notebook controller and all connected repos
         maintainers:


### PR DESCRIPTION
In support of #4 & #12, this PR creates a new `odh-model-controller respository Write` team to replace the Developers team with the same members and permissions

Replaces #1 