### PR TITLE
Get Triage access to the Notebook Controller

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -353,6 +353,7 @@ orgs:
         - LaVLaS
         - VaishnaviHire
         members:
+        - harshad16
         - maroroman
         - mlassak
         privacy: closed


### PR DESCRIPTION
Get Triage access to the Notebook Controller

## Description

I would like to get Triage access being a reviewer of the notebook controller
https://github.com/opendatahub-io/kubeflow/blob/25375774972d399c77195ec1c9d8a5de47f0fcfc/OWNERS

