### PR TITLE
Get Admin access to the Notebook Repo

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -412,6 +412,7 @@ orgs:
         - VaishnaviHire
         members:
         - atheo89
+        - harshad16
         privacy: closed
         repos:
           notebooks: admin


### PR DESCRIPTION
Get Admin access to the Notebook Repo

## Description

I would like admin access to the notebook repo, being an approval and review of the component
https://github.com/opendatahub-io/notebooks/blob/main/OWNERS

