### PR TITLE
Create Service Mesh Integration team

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -70,6 +70,10 @@ orgs:
     - vconzola
     - VedantMahabaleshwarkar
     - Xaenalt
+    - bartoszmajsak
+    - cam-garrison
+    - InnocentK
+    - aslakknutsen
     members_can_create_repositories: false
     name: Open Data Hub
     teams:
@@ -510,4 +514,21 @@ orgs:
         privacy: closed
         repos:
           opendatahub.io: triage
+      Service Mesh Integration:
+        description: Users with access to repos required to develop/maintain Service Mesh related features
+        maintainers:
+        - aslakknutsen
+        members:
+        - bartoszmajsak
+        - cam-garrison
+        - InnocentK
+        - aslakknutsen
+        - israel-hdez
+        privacy: closed
+        repos:
+          odh-dashboard: write
+          odh-manifests: write
+          odh-model-controller: write
+          opendatahub-operator: write
+          modelmesh-serving: write
 


### PR DESCRIPTION
## Description

Add a new team to the ODH org to give access to given repos for the active Service Mesh integration work.

## How Has This Been Tested?

No

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
