### PR TITLE
Add ezidav to opendatahub.io Triage team

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -510,6 +510,7 @@ orgs:
         maintainers:
         - LaVLaS
         members:
+        - ezidav
         - maroroman
         privacy: closed
         repos:


### PR DESCRIPTION
Add user @ezidav to the @opendatahub-io/opendatahub-io-triage Team