### PR TITLE
Create ODH Community Maintainers

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -394,6 +394,7 @@ orgs:
         maintainers:
         - jkoehler-redhat
         members:
+        - andrewballantyne
         - alexcreasy
         - Gkrumbach07
         - lucferbux
@@ -430,6 +431,16 @@ orgs:
         privacy: closed
         repos:
           opendatahub-operator: admin
+      ODH Community Maintainers:
+        description: Maintainers of the ODH Community repo
+        maintainers:
+          - jkoehler-redhat
+          - LaVLaS
+        members:
+          - andrewballantyne
+        privacy: closed
+        repos:
+          opendatahub-community: maintain
       ODH Org Admin:
         description: Administrators of the ODH org. Members have all permissions.
         maintainers:
@@ -536,4 +547,3 @@ orgs:
           odh-model-controller: write
           opendatahub-operator: write
           modelmesh-serving: write
-


### PR DESCRIPTION
Adding a group for maintaining issues in https://github.com/opendatahub-io/opendatahub-community

/hold

I still need to add a few others... but I wanted to get this out before complicating things to see what the process is.

FWIW, the HOWTO doesn't link to the binary -- it's a relative link that doesn't go anywhere. https://github.com/opendatahub-io/org-management/blob/main/HOWTO.md#how-to-run-the-peribolos