### PR TITLE
Add etirelli to opendatahub-operator and opendatahub-community maintainers

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -435,6 +435,7 @@ orgs:
       ODH Operator Maintainers:
         description: Maintainers of the ODH Operator repo
         maintainers:
+        - etirelli
         - LaVLaS
         - VaishnaviHire
         privacy: closed
@@ -443,6 +444,7 @@ orgs:
       ODH Community Maintainers:
         description: Maintainers of the ODH Community repo
         maintainers:
+          - etirelli
           - jkoehler-redhat
           - LaVLaS
         members:


### PR DESCRIPTION
Add etirelli to opendatahub-operator and opendatahub-community maintainers

## New Open Data Hub Member Requirements
- [X] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [X] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [X] New members are added in alphabetical order
- [X] Only one new member change per commit (if you add two members separate it in two commits
- [X] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members

