### PR TITLE
Revert "Use org token for merge workflow"

### DIFF
--- a/.github/workflows/approval_check.yml
+++ b/.github/workflows/approval_check.yml
@@ -31,4 +31,4 @@ jobs:
             });
             console.log(response.data);
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_MANAGEMENT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts opendatahub-io/org-management#71

This secret shouldn't be required by the approval workflow. 