### PR TITLE
Remove the duplicate maintainer & member from dsp maintainers

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -137,8 +137,6 @@ orgs:
         - amadhusu
         - DharmitD
         - gmfrasca
-        - gregsheremeta
-        - HumairAK
         - rimolive
         privacy: closed
         repos:


### PR DESCRIPTION
## Description
Fixes an error when running peribolos due to members in the `Data Science Pipelines Maintainers` team existing as `maintainers` and `members`