### PR TITLE
added new repo caikit-tgis-serving

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -199,6 +199,7 @@ orgs:
           caikit: admin
           caikit-nlp: admin
           caikit-tgis-backend: admin
+          caikit-tgis-serving: admin
           kserve: admin
           modelmesh: admin
           modelmesh-runtime-adapter: admin


### PR DESCRIPTION
to mlserving team

## Description
We had created new repo [caikit-tgis-serving](https://github.com/opendatahub-io/caikit-tgis-serving) into ODH. Model Serving team will maintain those. PR is requesting admin access to those repos for model serving team.

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [x] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [x] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
