### PR TITLE
Add winklerm to org members and distributed workloads maintainers

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -103,6 +103,7 @@ orgs:
     - yannnz
     - yih-wang
     - vaibhavjainwiz
+    - winklerm
     - zdtsw
     members_can_create_repositories: false
     name: Open Data Hub
@@ -170,6 +171,7 @@ orgs:
         - sutaakar
         - tedhtchang
         - VanillaSpoon
+        - winklerm
         privacy: closed
         repos:
           distributed-workloads: maintain


### PR DESCRIPTION
## Description
Joined OpenShift AI QE team, requesting access as part of onboarding.

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [x] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
