### PR TITLE
Clean-Up: Re-Adjust the Notebook teams to consolidate all work of notebooks

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -274,28 +274,31 @@ orgs:
           opendatahub-community: triage
           rest-proxy: admin
           text-generation-inference: admin
-      Notebook Controller Maintainers:
+      Notebook Maintainers:
         description: Maintainers of the notebook controller and all connected repos
         maintainers:
         - LaVLaS
         - harshad16
+        - atheo89
         privacy: closed
         repos:
           kubeflow: admin
-      Notebook Controller Triage:
+          notebooks: admin
+      Notebook Devs:
         description: Members with triage access to repos maintained by the Notebook
-          Controller contributors
+          contributors
         maintainers:
         - LaVLaS
-        members:
-        - dibryant
         - harshad16
-        - maroroman
+        members:
+        - atheo89
+        - dibryant
         - mlassak
         - rkpattnaik780
         privacy: closed
         repos:
           kubeflow: triage
+          notebooks: triage
       ODH Dashboard UX:
         description: UX team working on the ODH Dashboard component
         maintainers:
@@ -364,16 +367,6 @@ orgs:
         privacy: closed
         repos:
           opendatahub-documentation: admin
-      ODH Notebook Admins:
-        description: Team responsible for managing the ODH Core notebook repository
-        maintainers:
-        - LaVLaS
-        members:
-        - atheo89
-        - harshad16
-        privacy: closed
-        repos:
-          notebooks: admin
       ODH Operator Maintainers:
         description: Maintainers of the ODH Operator repo
         maintainers:


### PR DESCRIPTION
## Description
<!-- Provide full justification for why this organization membership change is being requested -->
<!-- Identify the relevant sponsors or maintainers for each team where a new user is being added -->

Re-Adjust the Notebook teams to consolidate all work of notebooks

Instead of 2 separate team for notebook and kubeflow.
consolidating both into 1. 
Going further, we will only have notebook  maintainer (admin), and notebook devs (triage)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
