### PR TITLE
Remove non-existent model-registry repo

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -208,8 +208,6 @@ orgs:
         - lampajr
         - tarilabs
         privacy: closed
-        repos:
-          model-registry: admin
       Model Serving Maintainers:
         description: "Maintainers for Model Serving related repos."
         maintainers:


### PR DESCRIPTION
## Description
The `Model Registry Maintainers` team has a reference to the `model-registry` (#111) repo that does not exist which caused an error when syncing the file.