### PR TITLE
Add ajaganat to opendatahub.io, odh-manifests repository Contributors and ODH Operator Maintainers

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -18,6 +18,7 @@ orgs:
     - uidoyen
     - abhijeet-dhumal
     - adelton
+    - ajaganat
     - ajaypratap003
     - akchinSTC
     - alexcreasy
@@ -143,6 +144,7 @@ orgs:
         - LaVLaS
         - VaishnaviHire
         members:
+        - ajaganat
         - ajaypratap003
         - harshad16
         - VannTen
@@ -359,6 +361,8 @@ orgs:
         - LaVLaS
         - VaishnaviHire
         - zdtsw
+        members:
+        - ajaganat        
         privacy: closed
         repos:
           opendatahub-operator: admin


### PR DESCRIPTION
## Description
Adding Ajay Jaganathan (ID: ajaganat) to ODH org and as member of opendatahub.io, odh-manifests repository Contributors and ODH Operator Maintainers

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [x] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [x] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [x] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [x] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
