### PR TITLE
Add gmarkley-vi to opendatahub-io admins

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -4,6 +4,7 @@ orgs:
     - accorvin
     - catrobson
     - cfchase
+    - gmarkley-vi
     - jkoehler-redhat
     - LaVLaS
     - openshift-ci-robot


### PR DESCRIPTION
## Description
Adding Gabriel Markley a Sr. Manager leading UI and IDE, to the admins section.
