### PR TITLE
Adding Xaenalt as maintainer for model serving

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -254,12 +254,12 @@ orgs:
         - heyselbi
         - Jooho
         - taneem-ibrahim
+        - Xaenalt
         members:
         - dtrifiro
         - israel-hdez
         - vaibhavjainwiz
         - VedantMahabaleshwarkar
-        - Xaenalt
         privacy: closed
         repos:
           caikit: admin
@@ -272,6 +272,7 @@ orgs:
           modelmesh-serving: admin
           odh-model-controller: admin
           opendatahub-community: triage
+          openvino_model_server: admin
           rest-proxy: admin
           text-generation-inference: admin
       Notebook Maintainers:


### PR DESCRIPTION
## Description
Need the power to fork repos to ODH, notably OVMS as we bring it up to date and in line with our build processes