### PR TITLE
Add jeremyeder as a maintainer of the architecture-decision-records repo

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -475,6 +475,7 @@ orgs:
         maintainers:
         - etirelli
         - gregsheremeta
+        - jeremyeder
         - LaVLaS
         privacy: closed
         repos:


### PR DESCRIPTION
## Description

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members

/assign @LaVLaS 
/cc @jeremyeder 