### PR TITLE
Remove maroroman from org teams

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -293,7 +293,6 @@ orgs:
         members:
         - dibryant
         - harshad16
-        - maroroman
         - mlassak
         - rkpattnaik780
         privacy: closed
@@ -324,7 +323,6 @@ orgs:
         members:
         - anishasthana
         - jenny-s51
-        - maroroman
         privacy: closed
         repos:
           odh-dashboard: write
@@ -496,7 +494,6 @@ orgs:
         - LaVLaS
         members:
         - ezidav
-        - maroroman
         privacy: closed
         repos:
           opendatahub.io: triage


### PR DESCRIPTION
## Description
Remove maroroman from github teams as he has moved on to a bigger and better role 

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
