### PR TITLE
Update permissions for VaishnaviHire

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -279,7 +279,6 @@ orgs:
         description: Maintainers of the notebook controller and all connected repos
         maintainers:
         - LaVLaS
-        - VaishnaviHire
         - harshad16
         privacy: closed
         repos:
@@ -289,7 +288,6 @@ orgs:
           Controller contributors
         maintainers:
         - LaVLaS
-        - VaishnaviHire
         members:
         - dibryant
         - harshad16
@@ -371,7 +369,6 @@ orgs:
         description: Team responsible for managing the ODH Core notebook repository
         maintainers:
         - LaVLaS
-        - VaishnaviHire
         members:
         - atheo89
         - harshad16
@@ -405,6 +402,7 @@ orgs:
           - keklundrh
           - kywalker-rh
           - RobGeada
+          - VaishnaviHire
         privacy: closed
         repos:
           opendatahub-community: maintain
@@ -487,6 +485,7 @@ orgs:
           repos
         maintainers:
         - LaVLaS
+        - VaishnaviHire
         members:
         - Gkrumbach07
         privacy: closed
@@ -499,6 +498,7 @@ orgs:
         members:
         - ezidav
         - maroroman
+        - VaishnaviHire
         privacy: closed
         repos:
           opendatahub.io: triage


### PR DESCRIPTION
## Description
This commit makes following changes

- Remove user from Notebook maintainers list
- Add user as an admin for opendatahub.io repo

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
