### PR TITLE
Add dchourasia to opendatahub-io as an admin

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -11,6 +11,7 @@ orgs:
     - openshift-merge-robot
     - shgriffi
     - taneem-ibrahim
+    - dchourasia
     default_repository_permission: read
     description: "Organization for Open Data Hub community"
     has_organization_projects: true

--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -4,6 +4,7 @@ orgs:
     - accorvin
     - catrobson
     - cfchase
+    - dchourasia
     - gmarkley-vi
     - jkoehler-redhat
     - LaVLaS
@@ -11,7 +12,6 @@ orgs:
     - openshift-merge-robot
     - shgriffi
     - taneem-ibrahim
-    - dchourasia
     default_repository_permission: read
     description: "Organization for Open Data Hub community"
     has_organization_projects: true


### PR DESCRIPTION
## Description
Need to maintain the DevOps App which has an immediate need for syncing all upstream github issues to the github board and would be needed for more such automation in future
<!-- Identify the relevant sponsors or maintainers for each team where a new user is being added -->

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [x] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [x] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [x] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [x] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
