### PR TITLE
Add dgutride to opendatahub-io, odh-dashboard

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -45,6 +45,7 @@ orgs:
     - danielezonca
     - devguyio
     - dfeddema
+    - dgutride
     - DharmitD
     - dhirajsb
     - dlabaj
@@ -315,6 +316,7 @@ orgs:
         description: UX team working on the ODH Dashboard component
         maintainers:
         - andrewballantyne
+        - dgutride
         - kywalker-rh
         members:
         - cfullam1
@@ -332,6 +334,7 @@ orgs:
         description: Contributors to Dashboard
         maintainers:
         - andrewballantyne
+        - dgutride
         - jkoehler-redhat
         members:
         - anishasthana
@@ -344,6 +347,7 @@ orgs:
         maintainers:
         - andrewballantyne
         - cfchase
+        - dgutride
         - LaVLaS
         members:
         - DaoDaoNoCode
@@ -360,6 +364,7 @@ orgs:
         description: Dashboard Owners
         maintainers:
         - andrewballantyne
+        - dgutride
         - jkoehler-redhat
         members:
         - alexcreasy
@@ -400,6 +405,7 @@ orgs:
         members:
           - andrewballantyne
           - anishasthana
+          - dgutride
           - heyselbi
           - jedemo
           - keklundrh


### PR DESCRIPTION
## Description
I recently joined the OpenShift AI project and will be working on OpenDataHub.

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [x] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [x] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
