### PR TITLE
Remove LaVLaS from Notebook teams

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -291,7 +291,6 @@ orgs:
       Notebook Maintainers:
         description: Maintainers of the notebook controller and all connected repos
         maintainers:
-        - LaVLaS
         - harshad16
         - atheo89
         - adrielparedes
@@ -303,7 +302,6 @@ orgs:
         description: Members with triage access to repos maintained by the Notebook
           contributors
         maintainers:
-        - LaVLaS
         - harshad16
         - adrielparedes
         members:


### PR DESCRIPTION
## Description
Remove @LaVLaS from the notebook teams.  Also using this as a test of the peribolos github action

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
