### PR TITLE
Enable admin for caikit-tgis-client repo

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -284,6 +284,7 @@ orgs:
           caikit: admin
           caikit-nlp: admin
           caikit-tgis-backend: admin
+          caikit-tgis-client: admin
           caikit-tgis-serving: admin
           kserve: admin
           modelmesh: admin


### PR DESCRIPTION
Added caikit-tgis-client repo, need admin powers on it

