### PR TITLE
Add rkubis to the opendatahub-io maintainers list

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -127,6 +127,7 @@ orgs:
     - rbcgh
     - rimolive
     - rkpattnaik780
+    - rkubis
     - RobGeada
     - romeokienzler
     - rpancham
@@ -277,6 +278,7 @@ orgs:
         - isinyaaa
         - lampajr
         - rareddy
+        - rkubis
         - tarilabs
         - tonyxrmdavidson
         members:


### PR DESCRIPTION
## Description
<!-- Provide full justification for why this organization membership change is being requested -->
<!-- Identify the relevant sponsors or maintainers for each team where a new user is being added -->

I am QE of Model Registry, for example @dhirajsb can confirm 😀 

## New Open Data Hub Member Requirements
- [x] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [x] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [x] New members are added in alphabetical order
- [x] Only one new member change per commit (if you add two members separate it in two commits
- [x] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [x] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [x] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
