### PR TITLE
Adding Tony Davidson to model registry as maintainer

### DIFF
--- a/config/opendatahub-io/org.yaml
+++ b/config/opendatahub-io/org.yaml
@@ -107,6 +107,7 @@ orgs:
     - lugi0
     - manaswinidas
     - manilmaskey
+    - MarianMacik
     - mattmahoneyrh
     - Maxusmusti
     - MichaelClifford
@@ -141,6 +142,7 @@ orgs:
     - tarilabs
     - tedhtchang
     - terrytangyuan
+    - tonyxrmdavidson
     - tteofili
     - VaishnaviHire
     - VanillaSpoon
@@ -273,6 +275,7 @@ orgs:
         - lampajr
         - rareddy
         - tarilabs
+        - tonyxrmdavidson
         members:
         - shawkins
         privacy: closed
@@ -588,7 +591,8 @@ orgs:
           - grdryn
           - gzaronikas
           - israel-hdez
-          - jackdelahunt  
+          - jackdelahunt
+          - MarianMacik
           - piotrpdev
           - Sara4994
           - steventobin


### PR DESCRIPTION
Add tonyxrmdavidson to model-registry as maintainer

## Description
<!-- Provide full justification for why this organization membership change is being requested -->
<!-- Identify the relevant sponsors or maintainers for each team where a new user is being added -->

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
