### PR TITLE
Use correct file path for github action trigger

### DIFF
--- a/.github/workflows/apply-org-membership.yaml
+++ b/.github/workflows/apply-org-membership.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'main'
     paths:
-      - "config/organization_membership.yaml"
+      - "config/organization_members.yaml"
 jobs:
   merge_membership_config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a typo in the path used for the github action to trigger applying org membership in response to membership changes. This change fixes that typo so that the automation will be triggered when we want it to.
<!--- Describe your changes in detail -->
