### PR TITLE
Add adolfo-ab to org members

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -6,6 +6,7 @@ orgs:
       - abhijeet-dhumal
       - adelton
       - adnankhan666
+      - adolfo-ab
       - adrielparedes
       - aduquett
       - AjayJagan


### PR DESCRIPTION
Add adolfo-ab as a member of the opendatahub-io organization.