### PR TITLE
Removing Eoin Gallinagh from org members

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -195,7 +195,6 @@ orgs:
       - vaibhavjainwiz
       - VaishnaviHire
       - VaniHaripriya
-      - VanillaSpoon
       - varshaprasad96
       - vconzola
       - VedantMahabaleshwarkar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Eoin Gallinagh with username VanillaSpoon has left Red Hat and therefore should be removed from the org members.