### PR TITLE
Add @ide-developer on opendatahub-io org

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -95,8 +95,8 @@ orgs:
       - hdefazio
       - heyselbi
       - HumairAK
-      - IKRedHat
       - ide-developer
+      - IKRedHat
       - isinyaaa
       - israel-hdez
       - jackdelahunt

--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -96,6 +96,7 @@ orgs:
       - heyselbi
       - HumairAK
       - IKRedHat
+      - ide-developer
       - isinyaaa
       - israel-hdez
       - jackdelahunt


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-16580

## Description
This is a bot account of IDE team. The scope of this account is to use it in order to generate tokens to use in IDE repositories for GHA workflows.
