### PR TITLE
Diego offboarding

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -2,7 +2,6 @@
 orgs:
   opendatahub-io:
     members:
-      - 4n4nd
       - abhijeet-dhumal
       - adelton
       - adnankhan666

--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -61,7 +61,6 @@ orgs:
       - DharmitD
       - dhirajsb
       - dibryant
-      - diegolovison
       - dimakis
       - dlabaj
       - dmartinol


### PR DESCRIPTION
Remove @diegolovison from ODH org as he is moving to a new team.
I noticed @4n4nd was also still in the org. He hasn't been involved with ODH for a few years now so updating that.