### PR TITLE
Fix organization_members.yaml order

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -75,13 +75,13 @@ orgs:
       - dtrifiro
       - durandom
       - ederign
+      - efazal
       - emilys314
       - erwangranger
       - etirelli
       - eturner24
       - evaline-ju
       - ezidav
-      - efazal
       - fcami
       - FedeAlonso
       - fialhocoelho


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The last merge was out of alphabetical order causing errors with future PRs.
