### PR TITLE
Add opendatahub-tests-bot to organization_members

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -178,6 +178,7 @@ orgs:
       - NickLucche
       - njhill
       - ntkathole
+      - opendatahub-tests-bot
       - openshift-ci-robot
       - openshift-merge-robot
       - paulovmr


### PR DESCRIPTION
## Description
Add `opendatahub-tests-bot` which is used in https://github.com/opendatahub-io/opendatahub-tests CI
