### PR TITLE
Remove from organization_members.yaml people no longer working in ODH

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -12,7 +12,6 @@ orgs:
       - agagancarczyk
       - aireilly
       - AjayJagan
-      - ajaypratap003
       - akchinSTC
       - akram
       - Al-Pragliola
@@ -34,7 +33,6 @@ orgs:
       - astefanutti
       - atheo89
       - bartoszmajsak
-      - biswassri
       - Bobbins228
       - bobbravo2
       - bredamc
@@ -166,7 +164,6 @@ orgs:
       - manosnoam
       - ManuelaAnsaldo
       - MarianMacik
-      - mattmahoneyrh
       - maxamillion
       - maxdebayser
       - Maxusmusti
@@ -271,7 +268,6 @@ orgs:
       - yannnz
       - Ygnas
       - yih-wang
-      - ykaliuta
       - YuliaKrimerman
       - z103cb
       - zdtsw

--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -116,7 +116,6 @@ orgs:
       - ikeola13
       - IKRedHat
       - israel-hdez
-      - jackdelahunt
       - jbusche
       - jbyrne-redhat
       - jedemo


### PR DESCRIPTION
Removing org members that left RHOAI/ODH
More specifically removing the following members:
Matt Mahoney
Yauheni Kaliuta
Srijoni Biswas
Ajay Pratap

