### PR TITLE
Add rhods-ci-bot to be used for ci of opendatahub-tests

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -207,6 +207,7 @@ orgs:
       - redhatHameed
       - resoluteCoder
       - RH-steve-grubb
+      - rhods-ci-bot
       - rimolive
       - rkubis
       - rnetser


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `rhods-ci-bot` as a member to the org. This bot would be used in https://github.com/opendatahub-io/opendatahub-tests CI
## Description
<!--- Describe your changes in detail -->
