### PR TITLE
Add danijett-design to organization_members.yaml

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -65,6 +65,7 @@ orgs:
       - dandawg
       - danielezonca
       - daniellutz
+      - danijett-design
       - DaoDaoNoCode
       - darachcawley
       - dbasunag


### PR DESCRIPTION
Adds danijett-design as a member of the organization as requested by @dimakis 

