### PR TITLE
Add rhuss to organization_members.yaml

### DIFF
--- a/config/organization_members.yaml
+++ b/config/organization_members.yaml
@@ -224,6 +224,7 @@ orgs:
       - resoluteCoder
       - RH-steve-grubb
       - rhods-ci-bot
+      - rhuss
       - rimolive
       - rkubis
       - rnetser


### PR DESCRIPTION
Add rhuss (Roland Huss) to members of opendatahub-io org
